### PR TITLE
docs: add agent blueprint and step templates

### DIFF
--- a/.codex/glossary.md
+++ b/.codex/glossary.md
@@ -1,0 +1,5 @@
+# Glossary
+- CCW: Coulisses Crew (project codename).
+- MVP: Minimal Viable Product.
+- CI: Continuous Integration.
+- E2E: End-to-end tests.

--- a/.codex/prompt_rules.md
+++ b/.codex/prompt_rules.md
@@ -1,0 +1,24 @@
+# Prompt Rules (Invariant)
+
+## STYLE AND SAFETY
+- ASCII only. No emojis. No secrets.
+- Windows-first. Prefer PowerShell 7 in PS1/ scripts. Fail fast.
+- Deterministic file contents. Avoid non-deterministic timestamps in committed files.
+
+## TECHNOLOGY BASELINE
+Backend: FastAPI, SQLAlchemy, Alembic, Pydantic v2, psycopg (pg), pytest, coverage.
+Frontend: React, TypeScript, Vite, Tailwind, shadcn, ESLint, Vitest, Playwright, Storybook.
+Infra: Docker Compose (dev), Caddy reverse proxy, GitHub Actions CI.
+
+## ACCEPTANCE GATES
+- Backend: pytest green; coverage >= 80 pct.
+- Frontend: eslint green; vitest green; Playwright smoke green.
+- `PS1/dev_up.ps1` boots the stack; `/api/healthz` OK behind Caddy.
+
+## PR POLICY
+- One focused PR per step. Small, auditable diffs. Conventional Commits.
+- Include PR template sections: Summary, Deliverables, How to run (Windows), Test Plan, Risks, Checklist.
+
+## EXECUTION ORDER
+- Read root AGENT.md -> resolve CURRENT TASK -> execute that step's AGENT.md.
+- On success: update root CHANGELOG, tick backlog item, set next CURRENT TASK.

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,62 @@
+# AGENT.md
+
+## SYSTEM
+Role: Lead Engineer agent for "Coulisses Crew" (Skello/EventSoft-like SaaS).
+Style: ASCII only. Deterministic. Windows-first. No secrets. Short, auditable diffs.
+Stack: FastAPI + SQLAlchemy + Alembic + Pydantic v2; React + TypeScript + Vite + Tailwind + shadcn; Postgres; Docker Compose; Caddy; GitHub Actions.
+
+## CI GATES
+Backend: pytest green; coverage >= 80 pct.
+Frontend: eslint green; vitest green; Playwright smoke green.
+Dev Stack: `PS1/dev_up.ps1` brings up db+backend+frontend+caddy. `/api/healthz` reachable via Caddy.
+
+## INVARIANT RULES
+The agent MUST obey `.codex/prompt_rules.md`.
+
+## REPO POLICY
+- Monorepo layout: backend/, frontend/, deploy/, PS1/, .github/workflows/, docs/.
+- Scripts: PowerShell 7+ under PS1/ (ASCII only). Fail fast. Deterministic outputs.
+- Env: `.env.example` required. Never commit secrets.
+- Commits: Conventional Commits. One focused PR per step.
+- Docs: Update docs/ and roadmap references when scope changes.
+
+## WORKFLOW
+1) Read this file and `.codex/prompt_rules.md`.
+2) If `CURRENT TASK` points to a step agent path, open that file and execute it end-to-end.
+3) Produce code, tests, CI, scripts, docs, and a PR body.
+4) Run TEST PLAN defined in the step agent. Ensure CI gates.
+5) Open a PR from the indicated branch. Include labels and checklists.
+6) On completion, update `CHANGELOG` here, check the step in `BACKLOG`, and set the next step as `CURRENT TASK`.
+
+## DIRECTORY LAYOUT
+See the File Tree in the project root. Step agents live under `agents/STEP_xx_name/AGENT.md`.
+
+## BACKLOG
+- [ ] STEP 00: Scaffold MVP monorepo + CI + PS1 + compose dev.  (agents/STEP_00_scaffold/AGENT.md)
+- [ ] STEP 01: Auth dev + RBAC minimal.                       (agents/STEP_01_auth_rbac/AGENT.md)
+- [ ] STEP 02: Missions + Assignments + conflits de base.     (agents/STEP_02_missions_assignments/AGENT.md)
+- [ ] STEP 03: Disponibilites + vue planning.                  (planned)
+- [ ] STEP 04: Comptabilite v1 (totaux mensuels + CSV).        (planned)
+- [ ] STEP 05: Audit log v1.                                   (planned)
+- [ ] STEP 06: Observabilite basique.                          (planned)
+
+## CURRENT TASK
+BASELINE ONLY. No build action yet. Set this to a step path when ready, e.g.:
+`CURRENT TASK: agents/STEP_00_scaffold/AGENT.md`
+
+## LINKS TO STEP AGENTS
+- agents/STEP_00_scaffold/AGENT.md
+- agents/STEP_01_auth_rbac/AGENT.md
+- agents/STEP_02_missions_assignments/AGENT.md
+
+## GIT AND PR RULES
+Branch naming: feat/<short-scope> or feat/step-xx-<slug>.
+Labels: area/backend, area/frontend, ci, scripts, docs.
+PR title: concise, Conventional Commits style.
+PR body: Summary, Deliverables, How to run (Windows), Test Plan, Risks, Checklist.
+
+## CHANGELOG
+- (empty)
+
+## RUN NOTE FOR THE AGENT
+When `CURRENT TASK` is set to a step path, read that step's AGENT.md and execute exactly as written. Do not deviate from invariant rules.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,14 @@
+# Step Agents
+Each step has its own `AGENT.md` under `agents/STEP_xx_name/`.
+The root `AGENT.md` points to the current step file via `CURRENT TASK`.
+
+Minimal sections per step file:
+- TITLE
+- GOAL
+- DELIVERABLES
+- FILES TO CREATE OR MODIFY
+- TEST PLAN (LOCAL)
+- CI GATES
+- GIT AND PR PLAN
+- DONE CRITERIA
+- CHANGELOG (append at end when done)

--- a/agents/STEP_00_scaffold/AGENT.md
+++ b/agents/STEP_00_scaffold/AGENT.md
@@ -1,0 +1,43 @@
+# STEP 00 - Scaffold MVP
+
+## GOAL
+Create a minimal working monorepo with CI and Windows-first scripts.
+
+## DELIVERABLES
+- backend/: FastAPI with `/healthz`, Alembic init, pytest + coverage config.
+- frontend/: Vite + React + TS, Tailwind + shadcn, Storybook, Vitest, Playwright smoke.
+- deploy/dev/: `compose.yaml` and `Caddyfile`.
+- PS1/: `dev_up.ps1`, `dev_down.ps1`, `seed.ps1`, `smoke.ps1`.
+- .github/workflows/: `backend.yml`, `frontend.yml`.
+- docs/: `README.fr.md`; root `.env.example`.
+- `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## FILES TO CREATE OR MODIFY
+List all files explicitly in the PR description. Keep diffs small and readable.
+
+## TEST PLAN (LOCAL)
+1) `./PS1/dev_up.ps1`
+2) Open http://localhost:8080
+3) Check http://localhost:8080/api/healthz returns `{ "status": "ok" }`
+4) `./PS1/smoke.ps1` (pytest, vitest, playwright smoke)
+
+## CI GATES
+- backend.yml: pytest with coverage >= 80 pct.
+- frontend.yml: lint, unit, Playwright smoke (install browsers with `--with-deps`).
+
+## GIT AND PR PLAN
+Branch: `feat/step-00-scaffold`
+PR title: `feat: scaffold MVP (monorepo, CI, PS1, compose)`
+Labels: area/backend, area/frontend, ci, scripts, docs
+PR Body sections: Summary, Deliverables, How to run (Windows), Test Plan, Risks, Checklist
+
+## DONE CRITERIA
+- Local smoke passes. CI green on the PR. Docs instruct Windows users clearly.
+
+## POST-MERGE UPDATE
+- Update root `AGENT.md` CHANGELOG.
+- Tick STEP 00 in BACKLOG.
+- Set CURRENT TASK to `agents/STEP_01_auth_rbac/AGENT.md`.
+
+## CHANGELOG
+- (empty)

--- a/agents/STEP_01_auth_rbac/AGENT.md
+++ b/agents/STEP_01_auth_rbac/AGENT.md
@@ -1,0 +1,30 @@
+# STEP 01 - Auth dev + RBAC minimal
+
+## GOAL
+Introduce development auth (fake provider acceptable) and minimal RBAC roles: admin, planner, tech.
+
+## DELIVERABLES
+- Backend: `/auth/login` (dev), role model, dependency to enforce roles; tests.
+- Frontend: basic auth flow (dev), role-aware UI toggles; tests.
+- Docs: brief on roles and dev auth toggle.
+
+## FILES TO CREATE OR MODIFY
+- backend: auth routes, role enums, guards, tests.
+- frontend: auth context/store, login form (dev), tests.
+
+## TEST PLAN (LOCAL)
+- Backend unit tests for role checks.
+- Frontend unit tests for role-gated components.
+
+## CI GATES
+- All green (backend, frontend, smoke).
+
+## GIT AND PR PLAN
+Branch: `feat/step-01-auth-rbac`
+PR title: `feat: auth dev and minimal RBAC`
+
+## DONE CRITERIA
+- Role enforcement proven by tests. UI reacts to role.
+
+## CHANGELOG
+- (empty)

--- a/agents/STEP_02_missions_assignments/AGENT.md
+++ b/agents/STEP_02_missions_assignments/AGENT.md
@@ -1,0 +1,30 @@
+# STEP 02 - Missions, Assignments, and Conflict Detection
+
+## GOAL
+Introduce Missions and Assignments models and endpoints with basic schedule conflict detection.
+
+## DELIVERABLES
+- Backend: models, migrations, endpoints, conflict check; tests.
+- Frontend: create mission + assign tech, show conflicts; tests.
+- Docs: API and UI notes.
+
+## FILES TO CREATE OR MODIFY
+- backend: models, CRUD, routes, tests, Alembic migration.
+- frontend: forms, calendar/list view, tests.
+
+## TEST PLAN (LOCAL)
+- Unit tests for overlap detection.
+- UI tests creating assignments and observing conflict badges.
+
+## CI GATES
+- All green (backend, frontend, smoke).
+
+## GIT AND PR PLAN
+Branch: `feat/step-02-missions-assignments`
+PR title: `feat: missions, assignments, conflict detection`
+
+## DONE CRITERIA
+- Conflicts detected deterministically by unit tests.
+
+## CHANGELOG
+- (empty)


### PR DESCRIPTION
## Summary
- add repository-wide AGENT instructions and step templates
- document invariant prompt rules and glossary

## Deliverables
- `AGENT.md`
- `.codex/prompt_rules.md`
- `.codex/glossary.md`
- `agents/README.md`
- `agents/STEP_00_scaffold/AGENT.md`
- `agents/STEP_01_auth_rbac/AGENT.md`
- `agents/STEP_02_missions_assignments/AGENT.md`

## How to run (Windows)
- n/a

## Test Plan
- `pytest`

## Risks
- none identified

## Checklist
- [x] docs
- [ ] backend
- [ ] frontend
- [ ] ci
- [ ] scripts


------
https://chatgpt.com/codex/tasks/task_e_68bd72a28fbc8330830ad8dd1cbfe325