### PR TITLE
fix(frontend-ci): avoid cache error when package-lock.json is missing

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -32,12 +32,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node (with cache)
+        if: ${{ hashFiles('frontend/package-lock.json') != '' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
+
+      - name: Setup Node (no cache, lockfile missing)
+        if: ${{ hashFiles('frontend/package-lock.json') == '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: Install deps
         working-directory: frontend


### PR DESCRIPTION
## Summary
- make Node setup cache conditional on package-lock

## Deliverables
- conditional setup-node steps in frontend workflow

## How to run (Windows)
- n/a (CI-only change)

## Test Plan
- `npm run lint --if-present`
- `npm test --if-present`
- `npx playwright install --with-deps` *(fails: dpkg lock)*

## Risks
- none

## Checklist
- [ ] CI green
- [ ] Docs updated
- [ ] Roadmap/Backlog updated

------
https://chatgpt.com/codex/tasks/task_e_68bd7d66f310833080f0b7b12f6e57b4