### PR TITLE
fix(frontend-tests): remove --ci for Vitest and set CI env

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -69,7 +69,9 @@ jobs:
 
       - name: Unit tests
         working-directory: frontend
-        run: npm test --if-present -- --ci
+        env:
+          CI: "true"
+        run: npm test --if-present
 
       - name: Playwright
         working-directory: frontend

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext .ts,.tsx",
-    "test": "vitest run src",
+    "test": "vitest run src --reporter=dot",
     "playwright:smoke": "playwright test tests/smoke.spec.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- remove unsupported `--ci` flag from frontend Vitest command and switch to dot reporter
- ensure frontend CI sets `CI=true` instead of passing `--ci`

## Deliverables
- `frontend/package.json`
- `.github/workflows/frontend.yml`

## How to Run (Windows)
1. `cd frontend`
2. `npm install`
3. `npm test`
4. `npm run lint`
5. `npx playwright install --with-deps`
6. `npm run playwright:smoke`

## Test Plan
- `npm run lint`
- `npm run typecheck --if-present`
- `CI=true npm test`
- `npx playwright install --with-deps` *(fails: server returned code 403)*
- `npm run playwright:smoke` *(fails: Chromium launch error)*

## Risks
- Playwright smoke tests require Chromium download; network blocks may cause failures.

## Checklist
- [x] Tests added/updated
- [ ] Docs added/updated


------
https://chatgpt.com/codex/tasks/task_e_68bd7ee23d1883308d234ab65d9b4779