### PR TITLE
fix: start preview server for Playwright tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx",
     "test": "vitest run src --reporter=dot",
     "playwright:smoke": "playwright test tests/smoke.spec.ts"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
     baseURL: 'http://localhost:8080',
     headless: true,
   },
+  webServer: {
+    command: 'npm run build && npm run preview -- --port 8080 --strictPort',
+    port: 8080,
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
   projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
 })


### PR DESCRIPTION
## Summary
- start Vite preview during Playwright runs
- expose preview npm script

## Deliverables
- Playwright configuration launching preview on port 8080
- package.json script `preview`

## How to run (Windows)
- `cd frontend`
- `npm install`
- `npx playwright install` (fails in sandbox)
- `npm run lint`
- `npm run test`
- `npm run playwright:smoke`

## Test Plan
- `npm run lint`
- `npm run test`
- `npm run playwright:smoke` *(fails: browser download forbidden)*
- `cd ..\backend; pytest`

## Risks
- Playwright browsers may not download in restricted environments.

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated


------
https://chatgpt.com/codex/tasks/task_e_68bd8e4e2c90833096fe56e7129341c4