### PR TITLE
feat: planning read-only view

### DIFF
--- a/PS1/dev_seed_planning.ps1
+++ b/PS1/dev_seed_planning.ps1
@@ -1,0 +1,22 @@
+param()
+python - <<'PY'
+from datetime import datetime, timezone
+from app.db import Base, engine, SessionLocal
+from app.planning import Event
+Base.metadata.create_all(engine)
+with SessionLocal() as s:
+    if not s.query(Event).count():
+        e = Event(
+            org_id=1,
+            project_id=None,
+            title="Demo",
+            start_utc=datetime(2025,1,1,tzinfo=timezone.utc),
+            end_utc=datetime(2025,1,1,1,tzinfo=timezone.utc),
+            location=None,
+            notes=None,
+            created_at_utc=datetime(2025,1,1,tzinfo=timezone.utc),
+            updated_at_utc=datetime(2025,1,1,tzinfo=timezone.utc),
+        )
+        s.add(e)
+        s.commit()
+PY

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# orga_5
+# Orga 5
+
+## Endpoints
+- `GET /v1/planning/events?from=ISO8601&to=ISO8601&project_id` : liste des evenements en UTC.
+- `GET /v1/planning/events/{event_id}` : evenement avec assignments.
+
+## Voir la vue planning
+```
+PS1\dev_up.ps1
+PS1\dev_seed_planning.ps1
+# puis ouvrir http://localhost:5173/planning
+```

--- a/backend/alembic/versions/0001_planning.py
+++ b/backend/alembic/versions/0001_planning.py
@@ -1,0 +1,38 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001_planning'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'events',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('org_id', sa.Integer, nullable=False),
+        sa.Column('project_id', sa.Integer, nullable=True),
+        sa.Column('title', sa.String, nullable=False),
+        sa.Column('start_utc', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('end_utc', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('location', sa.String, nullable=True),
+        sa.Column('notes', sa.Text, nullable=True),
+        sa.Column('created_at_utc', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at_utc', sa.DateTime(timezone=True), nullable=False),
+        sa.Index('ix_events_org_start', 'org_id', 'start_utc')
+    )
+    op.create_table(
+        'assignments',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('event_id', sa.Integer, sa.ForeignKey('events.id'), nullable=False),
+        sa.Column('person_id', sa.Integer, nullable=False),
+        sa.Column('role', sa.String, nullable=False),
+        sa.Column('status', sa.Enum('TENTATIVE','CONFIRMED','CANCELED', name='assignment_status'), nullable=False),
+        sa.Column('created_at_utc', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at_utc', sa.DateTime(timezone=True), nullable=False),
+        sa.Index('ix_assignments_event_id', 'event_id')
+    )
+
+def downgrade():
+    op.drop_table('assignments')
+    op.drop_table('events')

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+class Base(DeclarativeBase):
+    pass
+
+engine = create_engine("sqlite:///./app.db", future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+def get_session():
+    with SessionLocal() as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Depends
 from .auth import LoginRequest, Role, require_role
+from .planning import router as planning_router
 
 app = FastAPI()
 
@@ -14,3 +15,5 @@ def login(data: LoginRequest):
 @app.get("/admin", dependencies=[Depends(require_role(Role.admin))])
 def admin_area():
     return {"status": "admin"}
+
+app.include_router(planning_router, prefix="/v1/planning")

--- a/backend/app/planning.py
+++ b/backend/app/planning.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field, field_validator, model_validator
+from sqlalchemy import DateTime, Enum, ForeignKey, Index, String, Text, select
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
+
+from .db import Base, get_session
+
+class Assignment(Base):
+    __tablename__ = "assignments"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    event_id: Mapped[int] = mapped_column(ForeignKey("events.id"), index=True)
+    person_id: Mapped[int] = mapped_column()
+    role: Mapped[str] = mapped_column(String)
+    status: Mapped[str] = mapped_column(Enum("TENTATIVE", "CONFIRMED", "CANCELED", name="assignment_status"))
+    created_at_utc: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    updated_at_utc: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    org_id: Mapped[int] = mapped_column(index=True)
+    project_id: Mapped[int | None] = mapped_column(nullable=True)
+    title: Mapped[str] = mapped_column(String)
+    start_utc: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    end_utc: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    location: Mapped[str | None] = mapped_column(String, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at_utc: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    updated_at_utc: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+    assignments: Mapped[list[Assignment]] = relationship("Assignment", backref="event", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        Index("ix_events_org_start", "org_id", "start_utc"),
+    )
+
+class AssignmentOut(BaseModel):
+    id: int
+    person_id: int
+    role: str
+    status: Literal["TENTATIVE", "CONFIRMED", "CANCELED"]
+
+    class Config:
+        from_attributes = True
+
+class EventOut(BaseModel):
+    id: int
+    org_id: int
+    project_id: int | None
+    title: str
+    start_utc: datetime
+    end_utc: datetime
+    location: str | None
+    notes: str | None
+    assignments: list[AssignmentOut] = []
+
+    class Config:
+        from_attributes = True
+
+    @field_validator("start_utc", "end_utc")
+    @classmethod
+    def utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            return v.replace(tzinfo=timezone.utc)
+        if v.tzinfo != timezone.utc:
+            raise ValueError("must be UTC")
+        return v
+
+class EventQuery(BaseModel):
+    from_: datetime
+    to: datetime
+    project_id: int | None = None
+
+    model_config = {"populate_by_name": True}
+
+    @field_validator("from_", "to")
+    @classmethod
+    def utc(cls, v: datetime) -> datetime:
+        if v.tzinfo != timezone.utc:
+            raise ValueError("must be UTC")
+        return v
+
+    @model_validator(mode="after")
+    def check_range(self) -> "EventQuery":
+        if self.to <= self.from_:
+            raise ValueError("invalid range")
+        return self
+
+router = APIRouter()
+
+def _event_query(from_: datetime = Query(alias="from"), to: datetime = Query(), project_id: int | None = None) -> EventQuery:
+    return EventQuery(from_=from_, to=to, project_id=project_id)
+
+
+@router.get("/events", response_model=list[EventOut])
+def list_events(params: EventQuery = Depends(_event_query), session: Session = Depends(get_session)):
+    stmt = select(Event).where(Event.start_utc >= params.from_, Event.start_utc < params.to)
+    if params.project_id is not None:
+        stmt = stmt.where(Event.project_id == params.project_id)
+    return session.execute(stmt).scalars().all()
+
+@router.get("/events/{event_id}", response_model=EventOut)
+def get_event(event_id: int, session: Session = Depends(get_session)):
+    event = session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404)
+    return event

--- a/backend/tests/test_planning.py
+++ b/backend/tests/test_planning.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import pytest
+
+from app.main import app
+from app.db import Base, get_session
+from app.planning import Event
+
+engine = create_engine("sqlite:///./test.db", future=True)
+TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+Base.metadata.create_all(engine)
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    Base.metadata.drop_all(engine)
+    Base.metadata.create_all(engine)
+    yield
+
+def override_session():
+    with TestingSessionLocal() as session:
+        yield session
+
+app.dependency_overrides[get_session] = override_session
+
+
+def create_event(session, **kwargs):
+    evt = Event(**kwargs)
+    session.add(evt)
+    session.commit()
+    return evt
+
+
+def test_list_events_range():
+    with TestingSessionLocal() as session:
+        create_event(
+            session,
+            org_id=1,
+            project_id=None,
+            title="A",
+            start_utc=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            end_utc=datetime(2025, 1, 1, 1, tzinfo=timezone.utc),
+            location=None,
+            notes=None,
+            created_at_utc=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            updated_at_utc=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        )
+    client = TestClient(app)
+    resp = client.get(
+        "/v1/planning/events",
+        params={
+            "from": "2025-01-01T00:00:00Z",
+            "to": "2025-02-01T00:00:00Z",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["title"] == "A"
+
+
+def test_get_event_not_found():
+    client = TestClient(app)
+    resp = client.get("/v1/planning/events/999")
+    assert resp.status_code == 404
+
+
+def test_get_event():
+    with TestingSessionLocal() as session:
+        evt = create_event(
+            session,
+            org_id=1,
+            project_id=None,
+            title="B",
+            start_utc=datetime(2025, 1, 2, tzinfo=timezone.utc),
+            end_utc=datetime(2025, 1, 2, 1, tzinfo=timezone.utc),
+            location=None,
+            notes=None,
+            created_at_utc=datetime(2025, 1, 2, tzinfo=timezone.utc),
+            updated_at_utc=datetime(2025, 1, 2, tzinfo=timezone.utc),
+        )
+        event_id = evt.id
+    client = TestClient(app)
+    resp = client.get(f"/v1/planning/events/{event_id}")
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "B"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, FormEvent } from 'react'
 import { Button } from './components/ui/button'
 import { useAuth, Role } from './auth'
+import PlanningView from './planning'
 
 export default function App() {
   const { role, login, logout } = useAuth()
@@ -22,6 +23,15 @@ export default function App() {
         </select>
         <Button type="submit">Entrer</Button>
       </form>
+    )
+  }
+
+  if (window.location.pathname === '/planning') {
+    return (
+      <div className="p-4">
+        <PlanningView />
+        <Button onClick={logout}>Logout</Button>
+      </div>
     )
   }
 

--- a/frontend/src/planning.test.tsx
+++ b/frontend/src/planning.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import PlanningView from './planning'
+
+global.fetch = () => Promise.resolve({
+  json: () => Promise.resolve([{ id: 1, title: 'A', start_utc: '2025-01-01T10:00:00Z', end_utc: '2025-01-01T11:00:00Z' }])
+} as unknown as Response)
+
+test('shows events', async () => {
+  render(<PlanningView />)
+  await waitFor(() => screen.getByText('A (10:00)'))
+})

--- a/frontend/src/planning.tsx
+++ b/frontend/src/planning.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+
+interface Event {
+  id: number
+  title: string
+  start_utc: string
+  end_utc: string
+}
+
+export default function PlanningView() {
+  const [events, setEvents] = useState<Event[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const from = '2025-01-01T00:00:00Z'
+    const to = '2025-02-01T00:00:00Z'
+    fetch(`/v1/planning/events?from=${from}&to=${to}`)
+      .then(r => r.json())
+      .then(data => {
+        setEvents(data)
+        setLoading(false)
+      })
+  }, [])
+
+  if (loading) return <div>Loading...</div>
+  if (events.length === 0) return <div>No events</div>
+
+  const groups: Record<string, Event[]> = {}
+  events.forEach(e => {
+    const day = e.start_utc.split('T')[0]
+    groups[day] = groups[day] || []
+    groups[day].push(e)
+  })
+
+  return (
+    <div>
+      {Object.keys(groups).sort().map(day => (
+        <div key={day} className="mb-4">
+          <h2 className="font-bold">{day}</h2>
+          <ul>
+            {groups[day].map(ev => (
+              <li key={ev.id}>{ev.title} ({ev.start_utc.slice(11,16)})</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Event and Assignment models with Alembic migration and read-only planning endpoints
- provide React planning view fetching events and grouped by day
- document planning API and add seed script for demo data

## Deliverables
- backend Alembic migration and models
- /v1/planning/events and /v1/planning/events/{event_id}
- frontend /planning route with list view
- README update and dev_seed_planning.ps1

## How to Run (Windows)
```powershell
PS1\dev_up.ps1
PS1\dev_seed_planning.ps1
# open http://localhost:5173/planning
```

## Test Plan
- `cd backend; PYTHONPATH=. pytest`
- `cd frontend; npm run lint`
- `cd frontend; npm test`

## Risks
- SQLite date handling assumes UTC; other DBs may need tuning

## Checklist
- [x] Backend tests
- [x] Frontend lint
- [x] Frontend unit tests


------
https://chatgpt.com/codex/tasks/task_e_68bd9846aa008330b0bb4a9b013eea13