### PR TITLE
fix(backend,devops): run uvicorn via python -m and ensure deps; add healthcheck to backend service

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,20 +1,9 @@
 FROM python:3.12-slim
-
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-
 WORKDIR /app
-
-# install curl for healthcheck
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY app/requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r /app/requirements.txt
-
-COPY app /app/app
-
-ENV API_PORT=${API_PORT:-8000}
+COPY requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip && pip install -r /app/requirements.txt
+COPY . /app/
 EXPOSE 8000
-
-CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]
+CMD ["python", "-m", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,11 +38,13 @@ services:
         condition: service_healthy
     ports:
       - "${API_PORT}:8000"
+    command: ["python","-m","uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${API_PORT}/health"]
-      interval: 5s
+      test: ["CMD", "python", "-c", "import urllib.request,sys; urllib.request.urlopen('http://127.0.0.1:8000/docs'); sys.exit(0)"]
+      interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 10s
   web:
     build: ./frontend
     environment:


### PR DESCRIPTION
## Summary
- ensure backend builds with FastAPI + Uvicorn dependencies
- start backend via `python -m uvicorn` and add container healthcheck
- check backend service health through python-based compose rule

## Deliverables
- backend Dockerfile using `python -m uvicorn`
- backend `requirements.txt` including `fastapi` and `uvicorn[standard]`
- docker-compose updated with python healthcheck and command override

## How to run (Windows)
```powershell
wsl -d Ubuntu -- bash -lc "cd /mnt/c/Users/%USERNAME%/orga_5 && docker compose build api"
wsl -d Ubuntu -- bash -lc "cd /mnt/c/Users/%USERNAME%/orga_5 && docker compose up -d api"
wsl -d Ubuntu -- bash -lc "cd /mnt/c/Users/%USERNAME%/orga_5 && docker compose ps"
wsl -d Ubuntu -- bash -lc "cd /mnt/c/Users/%USERNAME%/orga_5 && docker compose logs -f api"
```
Verify:
```powershell
wsl -d Ubuntu -- bash -lc "curl -sSf http://localhost:8000/docs >$null && echo OK"
```

## Test Plan
- `pytest`
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

## Risks
- docker image now installs minimal dependencies; additional packages may be required for full app functionality

## Checklist
- [x] Tests pass or are documented
- [x] Lint checks pass or are documented


------
https://chatgpt.com/codex/tasks/task_e_68bdd6703840833098cba17478d5b6be