### PR TITLE
feat(frontend,infra): make Dockerfile resilient to missing lockfile and set compose build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-version: "3.9"
-
+# Compose V2: no top-level version key
 services:
   db:
     image: postgres:16-alpine
@@ -38,7 +37,9 @@ services:
       retries: 10
 
   web:
-    build: ./frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
     container_name: orga5_web
     depends_on:
       api:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.vite
+.cache
+# DO NOT ignore the lockfile
+!package-lock.json

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm ci --no-audit --no-fund
+# Use npm ci when lockfile is present, otherwise fallback to npm install
+RUN if [ -f package-lock.json ]; then \
+      npm ci --no-audit --no-fund; \
+    else \
+      npm install --no-audit --no-fund; \
+    fi
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- handle absence of package-lock.json in frontend Dockerfile by falling back to `npm install`
- build `web` service from `./frontend` and drop obsolete compose `version` key
- ignore build artifacts in frontend `.dockerignore` but keep `package-lock.json`

## Deliverables
- tolerant frontend Dockerfile with conditional install step
- docker-compose service `web` with explicit build context and Dockerfile
- `.dockerignore` ignoring `node_modules`, `dist`, `.vite`, `.cache`

## How to run (Windows)
```powershell
PS> wsl -d Ubuntu -- bash -lc "cd /mnt/c/Users/samue/orga_5 && docker compose build --no-cache web"
PS> wsl -d Ubuntu -- bash -lc "cd /mnt/c/Users/samue/orga_5 && docker compose up -d"
PS> wsl -d Ubuntu -- bash -lc "curl -sI http://localhost:8080 | head -n1"
```

## Test Plan
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `docker compose build web` *(fails: command not found in CI environment)*

## Risks
- none identified

## Checklist
- [x] Conventional Commit
- [x] Tests attempted
- [x] No secrets


------
https://chatgpt.com/codex/tasks/task_e_68bdde1de5b083309ff27057d9447d9e