### PR TITLE
fix(api): skip migrations when Alembic config missing

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,7 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --upgrade pip && pip install -r requirements.txt
 
 COPY . /app
+RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 8000
-CMD ["bash","-lc","python -m alembic -c /app/alembic.ini upgrade head && python -m uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -e
+
+cd /app
+
+if [ -f /app/alembic.ini ] && [ -d /app/migrations ]; then
+  echo "[entrypoint] Alembic config found. Running migrations..."
+  alembic upgrade head
+else
+  echo "[entrypoint] No Alembic config found. Skipping migrations."
+fi
+
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,15 +28,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    command: >
-      bash -lc "python -m alembic -c /app/alembic.ini upgrade head && python -m uvicorn app.main:app --host 0.0.0.0 --port 8000"
     ports:
       - "8000:8000"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
+      test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
 
   web:
     build:


### PR DESCRIPTION
## Summary
- add backend entrypoint that runs Alembic migrations when config present
- execute entrypoint from Dockerfile for backend image
- update compose to rely on entrypoint and healthcheck /docs

## Deliverables
- backend/entrypoint.sh
- backend/Dockerfile
- docker-compose.yml

## How to Run (Windows)
```powershell
docker compose build api
docker compose up -d api
```

## Test Plan
- `pytest` *(fails: missing httpx)*
- `docker compose build api` *(fails: command not found)*
- `docker compose up -d api` *(fails: command not found)*
- `docker logs orga5_api | tail -n 20` *(fails: command not found)*
- `curl -I http://localhost:8000/docs | head -n1` *(fails: couldn't connect)*

## Risks
- runtime dependencies may be missing in minimal image

## Checklist
- [ ] Tests added or updated
- [ ] Docs updated


------
https://chatgpt.com/codex/tasks/task_e_68bde8899f148330bde3ee7ccc91e357